### PR TITLE
Allow non-fn arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ function CallAll (fns) {
     var args = arguments
     var ret = new Array(fns.length)
     for (var i = 0, ii = fns.length; i < ii; i++) {
-      ret[i] = fns[i].apply(null, args)
+      ret[i] = !fns[i] ? undefined : fns[i].apply(null, args)
     }
     return ret
   }

--- a/test.js
+++ b/test.js
@@ -13,9 +13,10 @@ test(function (t) {
     function (value) {
       t.equal(value, 1, 'second call')
       return 1
-    }
+    },
+    false
   ])
-  t.deepEqual(all(1), [0, 1])
+  t.deepEqual(all(1), [0, 1, undefined])
 })
 
 test(function (t) {


### PR DESCRIPTION
This is the last thing I need to replace my fancy es6 utility function I use everywhere:

```js
const callAll = (...fns) => arg => fns.map(fn => fn && fn(arg))
```